### PR TITLE
add meta:description to course summary page

### DIFF
--- a/layout/includes/head.php
+++ b/layout/includes/head.php
@@ -32,6 +32,17 @@ $siteurl = new moodle_url('');
     <!-- CSS print media -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+    <?php
+    // Output metadescription for coursepage only
+    // Definitely could be improved.
+    if ($PAGE->pagetype == 'course-view-topics') {
+        echo '<!-- SEO data for course page only-->';
+        echo '<meta name="description" content="';
+        echo strip_tags($COURSE->summary);
+        echo '" >';
+    }
+    ?>
+
     <!-- Twitter Card data -->
     <meta name="twitter:card" value="summary">
     <meta name="twitter:site" value="<?php echo $SITE->fullname; ?>" />


### PR DESCRIPTION
Dear dev, thank you for your wonderful software. This short snippet adds a meta description to the course summary page, so that it shows up on sharing and SEO.